### PR TITLE
FIX #41 Azure Spring App tier should be "Standard"

### DIFF
--- a/infra/core/host/spring-apps-consumption.bicep
+++ b/infra/core/host/spring-apps-consumption.bicep
@@ -48,7 +48,7 @@ resource springApps 'Microsoft.AppPlatform/Spring@2023-05-01-preview' = {
   tags: tags
   sku: {
     name: 'S0'
-    tier: 'StandardGen2'
+    tier: 'Standard'
   }
   properties: {
     managedEnvironmentId: containerAppsEnvironment.id


### PR DESCRIPTION
## Purpose
Fix #41 by using "Standard" as Azure Spring Apps tier.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
azd init -t https://github.com/dbroeglin/app-templates-java-openai-springapps.git -b patch-1-fix-4-wrong-azure-spring-apps-tier
azd up
```

## What to Check

Deployment should succeed.

